### PR TITLE
[add] `//` comments

### DIFF
--- a/xkb-mode.el
+++ b/xkb-mode.el
@@ -70,7 +70,7 @@
   (setq font-lock-defaults
     `((
         ;; Comments
-        ("\\(#.*\\)" . font-lock-comment-face)
+        ("\\(\\(#\\|//\\).*\\)" . font-lock-comment-face)
         ;; Keywords and Sections
         (,(regexp-opt '("xkb_keycodes" "xkb_keymap" "xkb_types" "xkb_compatibility" "xkb_symbols" "xkb_geometry"
                          "useModMapMods" "virtual_modifiers" "type" "interpret" "action" "include" "name" "group"


### PR DESCRIPTION
Added support for `//` comments, they're quite common in the old configs found in `/usr/share/X11/xkb`.